### PR TITLE
Use Ollama4j for local AI summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llama3.2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # [Javadocs project documentation](https://couch-boy.github.io/CAB302-Project/)
+
+## Ollama Setup
+
+This project uses Ollama as a local LLM runtime.
+
+1. Install Ollama from the official website.
+2. Start Ollama.
+3. Pull the required model:
+
+   ```bash
+   ollama pull llama3.2
+   ```
+
+4. Make sure Ollama is running on:
+
+   ```text
+   http://localhost:11434
+   ```
+
+5. Run the Java application.
+
+Important:
+- Do not commit Ollama model files to the repository.
+- Each user must install Ollama and pull the required model on their own computer.
+- The project uses Ollama4j to communicate with the local Ollama server.
+- Optional configuration values are `OLLAMA_BASE_URL` and `OLLAMA_MODEL`; defaults are shown in `.env.example`.

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>json</artifactId>
       <version>20240303</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.ollama4j</groupId>
+      <artifactId>ollama4j</artifactId>
+      <version>1.1.7</version>
+    </dependency>
 
 <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/example/cab302project/OllamaService.java
+++ b/src/main/java/com/example/cab302project/OllamaService.java
@@ -1,27 +1,38 @@
 package com.example.cab302project;
 
-import org.json.JSONObject;
+import io.github.ollama4j.Ollama;
+import io.github.ollama4j.exceptions.OllamaException;
+import io.github.ollama4j.models.chat.OllamaChatMessage;
+import io.github.ollama4j.models.chat.OllamaChatMessageRole;
+import io.github.ollama4j.models.chat.OllamaChatRequest;
+import io.github.ollama4j.models.chat.OllamaChatResponseModel;
+import io.github.ollama4j.models.chat.OllamaChatResult;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 
 /**
  * Small helper for requesting crime summaries from a local Ollama model.
+ * Ollama4j wraps the local HTTP API so controllers do not need to build JSON requests directly.
  */
 public class OllamaService {
-    private static final String OLLAMA_URL = "http://localhost:11434/api/generate";
+    private static final String DEFAULT_BASE_URL = "http://localhost:11434";
     private static final String DEFAULT_MODEL = "llama3.2";
+    private static final int REQUEST_TIMEOUT_SECONDS = 30;
 
-    private final HttpClient httpClient;
+    private final Ollama ollama;
+    private final String model;
 
     public OllamaService() {
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
-                .build();
+        this(resolveConfigValue("OLLAMA_BASE_URL", DEFAULT_BASE_URL),
+                resolveConfigValue("OLLAMA_MODEL", DEFAULT_MODEL));
+    }
+
+    public OllamaService(String baseUrl, String model) {
+        this.ollama = new Ollama(baseUrl);
+        this.ollama.setRequestTimeoutSeconds(REQUEST_TIMEOUT_SECONDS);
+        this.model = model;
     }
 
     /**
@@ -29,33 +40,88 @@ public class OllamaService {
      *
      * @param prompt the complete prompt to send to the local model
      * @return the model response text
-     * @throws IOException if Ollama is not running or the response cannot be read
-     * @throws InterruptedException if the request is interrupted
+     * @throws IOException if Ollama is not running, the model is missing, or the response is invalid
      */
-    public String generateSummary(String prompt) throws IOException, InterruptedException {
-        // Ollama expects a small JSON body with the model, prompt, and stream=false for one response.
-        JSONObject requestJson = new JSONObject();
-        requestJson.put("model", DEFAULT_MODEL);
-        requestJson.put("prompt", prompt);
-        requestJson.put("stream", false);
+    public String generateSummary(String prompt) throws IOException {
+        try {
+            // The chat request maps to Ollama's local /api/chat endpoint with stream=false by default.
+            OllamaChatRequest request = OllamaChatRequest.builder()
+                    .withModel(model)
+                    .withMessage(OllamaChatMessageRole.USER, prompt)
+                    .build();
 
-        // The request stays local to Ollama; no external AI API or API key is required.
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(OLLAMA_URL))
-                .timeout(Duration.ofSeconds(30))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(requestJson.toString()))
-                .build();
+            // This method is called from a background JavaFX task, so the local model call cannot freeze the UI.
+            OllamaChatResult result = ollama.chat(request, null);
+            String response = extractResponseText(result);
 
-        // This method is called from a background thread so the blocking HTTP call does not freeze JavaFX.
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.isBlank()) {
+                throw new IOException("Ollama returned an empty response.");
+            }
 
-        if (response.statusCode() < 200 || response.statusCode() >= 300) {
-            throw new IOException("Ollama returned status " + response.statusCode());
+            return response;
+        } catch (OllamaException exception) {
+            throw toFriendlyIOException(exception);
+        }
+    }
+
+    /**
+     * Allows OLLAMA_BASE_URL and OLLAMA_MODEL to be supplied as environment variables or JVM properties.
+     */
+    private static String resolveConfigValue(String key, String defaultValue) {
+        String systemPropertyValue = System.getProperty(key);
+        if (systemPropertyValue != null && !systemPropertyValue.isBlank()) {
+            return systemPropertyValue.trim();
         }
 
-        // With stream=false, Ollama returns the generated text in the response JSON field.
-        JSONObject responseJson = new JSONObject(response.body());
-        return responseJson.optString("response", "").trim();
+        String environmentValue = System.getenv(key);
+        if (environmentValue != null && !environmentValue.isBlank()) {
+            return environmentValue.trim();
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Ollama4j returns a chat response model; this keeps response parsing in one reusable place.
+     */
+    private String extractResponseText(OllamaChatResult result) throws IOException {
+        if (result == null || result.getResponseModel() == null) {
+            throw new IOException("Ollama returned an unexpected response format.");
+        }
+
+        OllamaChatResponseModel responseModel = result.getResponseModel();
+        if (responseModel.getError() != null && !responseModel.getError().isBlank()) {
+            throw new IOException("Ollama error: " + responseModel.getError());
+        }
+
+        OllamaChatMessage message = responseModel.getMessage();
+        if (message == null || message.getResponse() == null) {
+            throw new IOException("Ollama response did not include assistant text.");
+        }
+
+        return message.getResponse().trim();
+    }
+
+    /**
+     * Converts common local Ollama failures into clearer messages for logging and controller fallbacks.
+     */
+    private IOException toFriendlyIOException(OllamaException exception) {
+        Throwable cause = exception.getCause();
+        String message = exception.getMessage() == null ? "" : exception.getMessage();
+        String lowerMessage = message.toLowerCase();
+
+        if (cause instanceof ConnectException || lowerMessage.contains("connection refused")) {
+            return new IOException("Ollama is not running at the configured local URL.", exception);
+        }
+
+        if (cause instanceof SocketTimeoutException || lowerMessage.contains("timed out") || lowerMessage.contains("timeout")) {
+            return new IOException("Ollama request timed out.", exception);
+        }
+
+        if (lowerMessage.contains("model") && (lowerMessage.contains("not found") || lowerMessage.contains("pull"))) {
+            return new IOException("Ollama model '" + model + "' is not available. Run: ollama pull " + model, exception);
+        }
+
+        return new IOException("Ollama summary request failed: " + message, exception);
     }
 }

--- a/src/main/java/com/example/cab302project/PoliceDashboardController.java
+++ b/src/main/java/com/example/cab302project/PoliceDashboardController.java
@@ -403,7 +403,7 @@ public class PoliceDashboardController {
         Thread summaryThread = new Thread(() -> {
             try {
                 String prompt = buildCrimeSummaryPrompt(suburbName, displayedCrimes);
-                // OllamaService sends the prompt to http://localhost:11434 using the llama3.2 model.
+                // OllamaService sends the prompt to local Ollama using the configured/default model.
                 String summary = ollamaService.generateSummary(prompt);
 
                 if (summary == null || summary.isBlank()) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module com.example.cab302project {
     requires java.sql;
     requires java.net.http;
     requires org.json;
+    requires ollama4j;
     requires org.kordamp.ikonli.core;
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.fontawesome5;


### PR DESCRIPTION
Refactors the AI crime summary feature to use Ollama4j instead of manual HTTP requests.

Adds Ollama setup documentation, .env.example defaults, and clearer error handling for missing/running Ollama or missing llama3.2 model.